### PR TITLE
add connector to retrieve SNMP counter data from ESnet's SNMP REST API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 sudo: required
 install:
-    - pip install coverage elasticsearch setuptools
+    - pip install coverage elasticsearch requests setuptools
     - python setup.py sdist
     - pip install dist/*
     - git clone -b darshan-3.1.5 https://xgitlab.cels.anl.gov/darshan/darshan.git || git clone -b darshan-3.1.5 https://github.com/glennklockwood/darshan.git

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,10 @@ def setup_package():
 
         # Dependencies
         install_requires=REQUIREMENTS,
-        extras_require={'collectdes': ['elasticsearch>=5.4']},
+        extras_require={
+            'collectdes': ['elasticsearch>=5.4'],
+            'esnet_snmp': ['requests'],
+        },
         python_requires=">=2.7",
 
         classifiers=[

--- a/tests/test_connectors_esnet_snmp.py
+++ b/tests/test_connectors_esnet_snmp.py
@@ -1,0 +1,176 @@
+"""Test the ESnet SNMP REST API connector
+"""
+
+import datetime
+import json
+
+import requests
+import nose
+
+import tokio.connectors.esnet_snmp
+
+ESNETSNMP_ENDPOINTS = {
+    'sunn-cr5': ['5_2_1'],
+    'sacr-cr5': ['4_2_1'],
+    'nersc-mr2': ['xe-0_1_0', 'xe-7_1_0'],
+}
+ESNETSNMP_END = datetime.datetime.now()
+ESNETSNMP_START = ESNETSNMP_END - datetime.timedelta(hours=1)
+
+def validate_last_response(esnetsnmp):
+    """Ensure that the REST API returns a known structure
+
+    Ensures that all return fields are present based on what we input.  Note
+    that we do not check for the existence of return data because the production
+    API endpoint seems to sometimes throttle requests in a way that returns an
+    empty 'data' member.
+
+    Args:
+        esnetsnmp (tokio.connectors.esnet_snmp.EsnetSnmp): the data structure to
+            validate
+        start (int): the requested start time, in seconds since epoch
+        end (int): the requested end time, in seconds since epoch
+        agg_func (str or None): the agg_func passed to the API endpoint, if any
+        interval (int or None): the interval passed to the API endpoint, if any
+
+    """
+    assert esnetsnmp
+    print(json.dumps(esnetsnmp.last_response))
+    assert 'end_time' in esnetsnmp.last_response
+    assert 'begin_time' in esnetsnmp.last_response
+    assert 'data' in esnetsnmp.last_response
+
+    if esnetsnmp.requested_agg_func is None:
+        assert 'agg' in esnetsnmp.last_response
+    else:
+        assert 'calc' in esnetsnmp.last_response
+
+    if esnetsnmp.requested_timestep is None:
+        assert 'cf' in esnetsnmp.last_response
+    else:
+        assert 'calc_func' in esnetsnmp.last_response
+
+    if esnetsnmp.start is not None:
+        print("begin_time: %s <= %s? %s" % (
+            esnetsnmp.last_response['begin_time'],
+            esnetsnmp.start_epoch,
+            (esnetsnmp.last_response['begin_time'] <= esnetsnmp.start_epoch)))
+        assert esnetsnmp.last_response['begin_time'] <= esnetsnmp.start_epoch
+
+    if esnetsnmp.end is not None:
+        print("end_time: %s >= %s? %s" % (
+            esnetsnmp.last_response['end_time'],
+            esnetsnmp.end_epoch,
+            (esnetsnmp.last_response['end_time'] >= esnetsnmp.end_epoch)))
+        assert esnetsnmp.last_response['end_time'] >= esnetsnmp.end_epoch
+
+def test_esnetsnmp_get_interface_counters():
+    """EsnetSnmp.get_interface_counters() basic functionality
+    """
+
+    endpoint = list(ESNETSNMP_ENDPOINTS)[0]
+    interface = ESNETSNMP_ENDPOINTS[endpoint][0]
+
+    # tests:
+    #  - minimum required inputs
+    #  - direction=='in'
+    #  - two-step initialize and populate
+    esnetsnmp = tokio.connectors.esnet_snmp.EsnetSnmp(
+        start=ESNETSNMP_START, end=ESNETSNMP_END)
+    try:
+        esnetsnmp.get_interface_counters(endpoint=endpoint,
+                                         interface=interface,
+                                         direction='in')
+    except requests.exceptions.ConnectionError as error:
+        raise nose.SkipTest(error)
+
+    validate_last_response(esnetsnmp)
+
+    # tests:
+    #  - minimum required inputs
+    #  - direction=='out'
+    #  - single-step initialize and populate
+    try:
+        esnetsnmp = tokio.connectors.esnet_snmp.EsnetSnmp(
+            start=ESNETSNMP_START,
+            end=ESNETSNMP_END,
+            endpoint=endpoint,
+            interface=interface,
+            direction='out')
+    except requests.exceptions.ConnectionError as error:
+        raise nose.SkipTest(error)
+
+    validate_last_response(esnetsnmp)
+
+    # tests:
+    #  - specifying all parameters
+    agg_func = 'max'
+    interval = 60
+    try:
+        esnetsnmp = tokio.connectors.esnet_snmp.EsnetSnmp(
+            start=ESNETSNMP_START,
+            end=ESNETSNMP_END,
+            endpoint=endpoint,
+            interface=interface,
+            direction='out',
+            agg_func=agg_func,
+            interval=interval)
+    except requests.exceptions.ConnectionError as error:
+        raise nose.SkipTest(error)
+
+    validate_last_response(esnetsnmp)
+
+    # ensure that response is valid (though this is more a test of the REST API
+    # returning correct results)
+    print("calc: %s == %s? %s" % (
+        int(esnetsnmp.last_response['calc']),
+        interval,
+        (int(esnetsnmp.last_response['calc']) == interval)))
+    assert int(esnetsnmp.last_response['calc']) == interval
+
+    print("calc_func: %s == %s? %s" % (
+        esnetsnmp.last_response['calc_func'].lower(),
+        agg_func.lower(),
+        esnetsnmp.last_response['calc_func'].lower() == agg_func.lower()))
+    assert esnetsnmp.last_response['calc_func'].lower() == agg_func.lower()
+
+def test_to_dataframe():
+    """EsnetSnmp.to_dataframe()
+    """
+    endpoint = list(ESNETSNMP_ENDPOINTS)[0]
+    interface = ESNETSNMP_ENDPOINTS[endpoint][0]
+
+    try:
+        esnetsnmp = tokio.connectors.esnet_snmp.EsnetSnmp(
+            start=ESNETSNMP_START,
+            end=ESNETSNMP_END,
+            endpoint=endpoint,
+            interface=interface,
+            direction='out')
+    except requests.exceptions.ConnectionError as error:
+        raise nose.SkipTest(error)
+
+    assert esnetsnmp
+    dataframe = esnetsnmp.to_dataframe()
+    assert len(dataframe)
+    print("dataframe has %d rows; raw result had %d rows" % (
+        len(dataframe),
+        len(esnetsnmp.last_response['data'])))
+    assert len(dataframe) == len(esnetsnmp.last_response['data'])
+
+    esnetsnmp.get_interface_counters(
+        endpoint=endpoint,
+        interface=interface,
+        direction='in')
+
+    dataframe = esnetsnmp.to_dataframe(multiindex=False)
+    print(dataframe)
+    print("dataframe has %d rows; last raw result had %d rows" % (
+        len(dataframe),
+        len(esnetsnmp.last_response['data'])))
+    assert len(dataframe) > len(esnetsnmp.last_response['data'])
+
+    print(json.dumps(esnetsnmp))
+
+    dataframe = esnetsnmp.to_dataframe(multiindex=True)
+    assert len(dataframe)

--- a/tokio/config.py
+++ b/tokio/config.py
@@ -61,7 +61,7 @@ def init_config():
 
     # Check for magic environment variables to override the contents of the config
     # file at runtime
-    for _magic_variable in ['HDF5_FILES', 'ISDCT_FILES', 'LFSSTATUS_FULLNESS_FILES', 'LFSSTATUS_MAP_FILES', 'DARSHAN_LOG_DIRS']:
+    for _magic_variable in ['HDF5_FILES', 'ISDCT_FILES', 'LFSSTATUS_FULLNESS_FILES', 'LFSSTATUS_MAP_FILES', 'DARSHAN_LOG_DIRS', 'ESNET_SNMP_URI']:
         _magic_value = os.environ.get("PYTOKIO_" + _magic_variable)
         if _magic_value is not None:
             try:

--- a/tokio/connectors/__init__.py
+++ b/tokio/connectors/__init__.py
@@ -48,3 +48,8 @@ try:
     import tokio.connectors.slurm
 except ImportError:
     pass
+
+try:
+    import tokio.connectors.esnet_snmp
+except ImportError:
+    pass

--- a/tokio/connectors/esnet_snmp.py
+++ b/tokio/connectors/esnet_snmp.py
@@ -1,0 +1,256 @@
+"""Provides interfaces into ESnet's SNMP REST API
+
+Documentation for the REST API is here:
+
+    http://es.net/network-r-and-d/data-for-researchers/snmp-api/
+
+Relies either on the 'esnet_snmp_uri' configuration value being set in the
+pytokio configuration or the PYTOKIO_ESNET_SNMP_URI being defined in the
+environment.
+"""
+
+import time
+import json
+import datetime
+import warnings
+
+import requests
+import pandas
+
+from .. import config
+from . import common
+
+
+class EsnetSnmp(common.CacheableDict):
+    """Container for ESnet SNMP counters
+
+    Dictionary with structure::
+
+        {
+            "endpoint0": {
+                "interface_x": {
+                    "in": {
+                        timestamp1: value1,
+                        timestamp2: value2,
+                        timestamp3: value3,
+                        ...
+                    },
+                    "out": { ... }
+                },
+                "interface_y": { ... }
+            },
+            "endpoint1": { ... }
+        }
+
+    Various methods are provided to access the data of interest.
+    """
+    def __init__(self, start, end, endpoint=None, interface=None, direction=None, agg_func=None, interval=None):
+        """Retrieves data rate data for an ESnet endpoint
+
+        Initializes the object with a start and end time.  Optionally runs a
+        REST API query if endpoint, interface, and direction are provided.
+        Assumes that once the start/end time have been specified, they should
+        not be changed.
+
+        Args:
+            start (datetime.datetime): Start of interval to retrieve, inclusive
+            end (datetime.datetime): End of interval to retrieve, inclusive
+            endpoint (str, optional): Name of the ESnet endpoint whose data is
+                being retrieved
+            interface (str, optional): Name of the ESnet endpoint interface on
+                the specified endpoint
+            direction (str, optional): "in" or "out" to signify data input into
+                ESnet or data output from ESnet
+            agg_func (str, optional ): Specifies the reduction operator to be
+                applied over each interval; must be one of "average," "min," or "max."  If None, uses the ESnet default.
+            interval (int, optional ): Resolution, in seconds, of the data to be
+                returned.  If None, uses the ESnet default.
+
+        Attributes:
+            start (datetime.datetime): Start of interval represented by this object, inclusive
+            end (datetime.datetime): End of interval represented by this object, inclusive
+            start_epoch (int): Seconds since epoch for self.start
+            end_epoch (int): Seconds since epoch for self.end
+        """
+
+        super(EsnetSnmp, self).__init__()
+
+        if start >= end:
+            raise RuntimeError("Start must be greater than or equal to end")
+
+        # input parameters
+        self.start = start
+        self.end = end
+        self.start_epoch = int(time.mktime(self.start.timetuple()))
+        self.end_epoch = int(time.mktime(self.end.timetuple()))
+        self.requested_timestep = interval
+        self.requested_endpoint = endpoint
+        self.requested_interface = interface
+        self.requested_direction = direction
+        self.requested_agg_func = agg_func
+
+        # output parameters
+        self.last_response = None
+        self.timestep = None
+
+        if endpoint and interface and direction:
+            self.get_interface_counters(endpoint=endpoint,
+                                        interface=interface,
+                                        direction=direction,
+                                        agg_func=agg_func,
+                                        interval=interval)
+
+    def _insert_result(self):
+        """Parse the raw output of the REST API and update self
+
+        ESnet's REST API will return an object like::
+
+            {
+                "agg": "30",
+                "begin_time": 1517471100,
+                "end_time": 1517471910,
+                "cf": "average",
+                "data": [
+                    [
+                        1517471100,
+                        5997486471.266666
+                    ],
+            ...
+                    [
+                        1517471910,
+                        189300026.8
+                    ]
+                ]
+            }
+
+        Args:
+            result (dict): JSON structure returned by the ESnet REST API
+
+        Returns:
+            bool: True if data inserted without errors; False otherwise
+        """
+
+        result = self.last_response
+        if not result:
+            print("no result; bailing")
+            return False
+
+        # set the timestep if not previously set
+        interval = _get_interval_result(result)
+        if interval:
+            if not self.timestep:
+                self.timestep = interval
+            elif self.timestep != interval:
+                warnings.warn("received timestep %d from an object with timestep %d" % (interval, self.timestep))
+
+        if self.requested_endpoint not in self:
+            self[self.requested_endpoint] = {}
+        if self.requested_interface not in self[self.requested_endpoint]:
+            self[self.requested_endpoint][self.requested_interface] = {}
+        if self.requested_direction not in self[self.requested_endpoint][self.requested_interface]:
+            self[self.requested_endpoint][self.requested_interface][self.requested_direction] = {}
+
+        data = result.get('data')
+        if not data:
+            warnings.warn("No data in result")
+
+        for timestamp, value in data:
+            self[self.requested_endpoint][self.requested_interface][self.requested_direction][timestamp] = value
+
+        return True
+
+    def get_interface_counters(self, endpoint, interface, direction, agg_func=None, interval=None):
+        """Retrieves data rate data for an ESnet endpoint
+
+        Args:
+            interface (str, optional): Name of the ESnet endpoint interface
+            direction (str): "in" or "out" to signify data input into ESnet or
+                data output from ESnet
+            agg_func (str or None): Specifies the reduction operator to be
+                applied over each interval; must be one of "average," "min," or
+                "max."  If None, uses the ESnet default.
+            interval (int or None): Resolution, in seconds, of the data to be
+                returned.  If None, uses the ESnet default.
+
+        Returns:
+           dict: raw return from the REST API call
+        """
+        if direction not in ['in', 'out']:
+            raise RuntimeError("direction must be either in or out")
+
+        self.requested_endpoint = endpoint
+        self.requested_interface = interface
+        self.requested_direction = direction
+        self.requested_agg_func = agg_func
+        self.requested_timestep = interval
+
+        if self.requested_timestep is not None \
+        and self.timestep is not None \
+        and self.requested_timestep != self.timestep:
+            warnings.warn("received timestep %d from an object with timestep %d" 
+                % (self.requested_timestep, self.timestep))
+
+        uri = config.CONFIG.get('esnet_snmp_uri')
+        if uri is None:
+            requests.exception.ConnectionError("no esnet_snmp_uri configured")
+        uri += '/%s/interface/%s/%s' % (endpoint, interface, direction)
+
+        params = {
+            'begin': self.start_epoch,
+            'end': self.end_epoch,
+        }
+        if agg_func is not None:
+            params['calc_func'] = agg_func
+        if interval is not None:
+            params['calc'] = interval
+
+        request = requests.get(uri, params=params)
+        self.last_response = json.loads(request.text)
+
+        self._insert_result()
+
+        return self.last_response
+
+    def to_dataframe(self, multiindex=False):
+        """Return data as a Pandas DataFrame
+
+        Args:
+            multiindex (bool): If True, return a DataFrame indexed by timestamp,
+                endpoint, interface, and direction
+        """
+
+        to_df = []
+
+        for endpoint, interfaces in self.items():
+            for interface, directions in interfaces.items():
+                for direction, data in directions.items():
+                    for timestamp, value in data.items():
+                        to_df.append({
+                            'endpoint': endpoint,
+                            'interface': interface,
+                            'direction': direction,
+                            'timestamp': datetime.datetime.fromtimestamp(timestamp),
+                            'data_rate': value,
+                        })
+
+        dataframe = pandas.DataFrame.from_records(to_df)
+        if multiindex:
+            return dataframe.set_index(['timestamp', 'endpoint', 'interface', 'direction'])
+
+        return dataframe
+
+def _get_interval_result(result):
+    """Parse the raw output of the REST API output and return the timestep
+
+    Args:
+        result (dict): the raw JSON output of the ESnet REST API
+    """
+    value = result.get('agg')
+    if value:
+        return int(value)
+
+    value = result.get('calc')
+    if 'calc' in result:
+        return int(value)
+
+    return None

--- a/tokio/connectors/esnet_snmp.py
+++ b/tokio/connectors/esnet_snmp.py
@@ -44,7 +44,14 @@ class EsnetSnmp(common.CacheableDict):
 
     Various methods are provided to access the data of interest.
     """
-    def __init__(self, start, end, endpoint=None, interface=None, direction=None, agg_func=None, interval=None):
+    def __init__(self,
+                 start,
+                 end,
+                 endpoint=None,
+                 interface=None,
+                 direction=None,
+                 agg_func=None,
+                 interval=None):
         """Retrieves data rate data for an ESnet endpoint
 
         Initializes the object with a start and end time.  Optionally runs a
@@ -62,7 +69,8 @@ class EsnetSnmp(common.CacheableDict):
             direction (str, optional): "in" or "out" to signify data input into
                 ESnet or data output from ESnet
             agg_func (str, optional ): Specifies the reduction operator to be
-                applied over each interval; must be one of "average," "min," or "max."  If None, uses the ESnet default.
+                applied over each interval; must be one of "average," "min," or
+                "max."  If None, uses the ESnet default.
             interval (int, optional ): Resolution, in seconds, of the data to be
                 returned.  If None, uses the ESnet default.
 
@@ -141,7 +149,8 @@ class EsnetSnmp(common.CacheableDict):
             if not self.timestep:
                 self.timestep = interval
             elif self.timestep != interval:
-                warnings.warn("received timestep %d from an object with timestep %d" % (interval, self.timestep))
+                warnings.warn("received timestep %d from an object with timestep %d"
+                              % (interval, self.timestep))
 
         if self.requested_endpoint not in self:
             self[self.requested_endpoint] = {}
@@ -187,12 +196,12 @@ class EsnetSnmp(common.CacheableDict):
         if self.requested_timestep is not None \
         and self.timestep is not None \
         and self.requested_timestep != self.timestep:
-            warnings.warn("received timestep %d from an object with timestep %d" 
-                % (self.requested_timestep, self.timestep))
+            warnings.warn("received timestep %d from an object with timestep %d"
+                          % (self.requested_timestep, self.timestep))
 
         uri = config.CONFIG.get('esnet_snmp_uri')
         if uri is None:
-            requests.exception.ConnectionError("no esnet_snmp_uri configured")
+            raise requests.exceptions.ConnectionError("no esnet_snmp_uri configured")
         uri += '/%s/interface/%s/%s' % (endpoint, interface, direction)
 
         params = {


### PR DESCRIPTION
Resolves #64 by adding a new REST API connector to access ESnet SNMP data